### PR TITLE
Remove the support for Python 3.7

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         # https://github.com/actions/python-versions/blob/main/versions-manifest.json
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         # Specify the Python versions you support here.
         "Programming Language :: Python :: 3",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     py_modules=["xml_sitemap_writer"],
     extras_require={
         "dev": [


### PR DESCRIPTION
Python 3.7 is due to reach its scheduled upstream end-of-life on June 27th, 2023