### PR TITLE
Add validation for <lastmod>, <priority>, and <changefreq> fields in XMLSitemap

### DIFF
--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -95,6 +95,10 @@ class XMLSitemap:
         priority: Optional[str] = None,
         changefreq: Optional[str] = None,
     ):
+        """
+        Adds the provided URL to the sitemap (with optional lastmod, priority and changefreq properties)
+        https://www.sitemaps.org/protocol.html#xmlTagDefinitions
+        """
         if self.sitemap_urls_counter == 0:
             self._add_sitemap()
 

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -10,9 +10,19 @@ from xml.sax.saxutils import escape as escape_xml
 
 POWERED_BY_URL = "https://github.com/pigs-will-fly/py-xml-sitemap-writer"
 
-W3C_DATE_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}$')
-W3C_DATETIME_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\+\d{2}:\d{2}|Z)?$')
-CHANGEFREQ_VALUES = {"always", "hourly", "daily", "weekly", "monthly", "yearly", "never"}
+W3C_DATE_REGEX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+W3C_DATETIME_REGEX = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\+\d{2}:\d{2}|Z)?$"
+)
+CHANGEFREQ_VALUES = {
+    "always",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+    "yearly",
+    "never",
+}
 
 def is_valid_date(date_str: str) -> bool:
     return W3C_DATE_REGEX.match(date_str) or W3C_DATETIME_REGEX.match(date_str)

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -103,7 +103,9 @@ class XMLSitemap:
             self.logger.warning(f"Invalid <lastmod> format for URL <{url}>: {lastmod}")
             lastmod = None
         if changefreq and not is_valid_changefreq(changefreq):
-            self.logger.warning(f"Invalid <changefreq> value for URL <{url}>: {changefreq}")
+            self.logger.warning(
+                f"Invalid <changefreq> value for URL <{url}>: {changefreq}"
+            )
             changefreq = None
         if priority and not is_valid_priority(priority):
             self.logger.warning(f"Invalid <priority> value for URL <{url}>: {priority}")

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -4,11 +4,28 @@ Provides XMLSitemap class used to generate large XML sitemap from iterators
 
 import gzip  # https://docs.python.org/3/library/gzip.html
 import logging
-
-from typing import List, Iterator, IO
+import re
+from typing import List, Iterator, IO, Optional
 from xml.sax.saxutils import escape as escape_xml
 
 POWERED_BY_URL = "https://github.com/pigs-will-fly/py-xml-sitemap-writer"
+
+W3C_DATE_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}$')
+W3C_DATETIME_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\+\d{2}:\d{2}|Z)?$')
+CHANGEFREQ_VALUES = {"always", "hourly", "daily", "weekly", "monthly", "yearly", "never"}
+
+def is_valid_date(date_str: str) -> bool:
+    return W3C_DATE_REGEX.match(date_str) or W3C_DATETIME_REGEX.match(date_str)
+
+def is_valid_changefreq(changefreq: str) -> bool:
+    return changefreq in CHANGEFREQ_VALUES
+
+def is_valid_priority(priority: str) -> bool:
+    try:
+        value = float(priority)
+        return 0.0 <= value <= 1.0
+    except ValueError:
+        return False
 
 
 # pylint:disable=too-many-instance-attributes
@@ -46,30 +63,41 @@ class XMLSitemap:
 
         self.add_section("pages")
 
-    def add_url(self, url: str):
-        """
-        Add a given URL to the sitemap
-        """
-        # lazily create a new sub-sitemap file
-        # see add_section() method
+
+    def add_url(self, url: str, lastmod: Optional[str] = None, priority: Optional[str] = None, changefreq: Optional[str] = None):
         if self.sitemap_urls_counter == 0:
             self._add_sitemap()
 
         self.total_urls_counter += 1
         self.sitemap_urls_counter += 1
 
-        # check per sitemap limits
         if self.sitemap_urls_counter > self.URLS_PER_FILE:
-            self.logger.info(
-                f"URLs per sitemap counter reached the limit of {self.URLS_PER_FILE}"
-            )
+            self.logger.info(f"URLs per sitemap counter reached the limit of {self.URLS_PER_FILE}")
             self._add_sitemap()
             self.sitemap_urls_counter = 1
 
         url = f'{self.root_url}/{url.lstrip("/")}'
 
+        if lastmod and not is_valid_date(lastmod):
+            self.logger.warning(f"Invalid <lastmod> format for URL <{url}>: {lastmod}")
+            lastmod = None
+        if changefreq and not is_valid_changefreq(changefreq):
+            self.logger.warning(f"Invalid <changefreq> value for URL <{url}>: {changefreq}")
+            changefreq = None
+        if priority and not is_valid_priority(priority):
+            self.logger.warning(f"Invalid <priority> value for URL <{url}>: {priority}")
+            priority = None
+
         self.logger.debug(f"Adding URL <{url}>")
-        self.write_to_sitemap(f"<url><loc>{escape_xml(url)}</loc></url>")
+        url_entry = f"<url><loc>{escape_xml(url)}</loc>"
+        if lastmod:
+            url_entry += f"<lastmod>{escape_xml(lastmod)}</lastmod>"
+        if priority:
+            url_entry += f"<priority>{escape_xml(priority)}</priority>"
+        if changefreq:
+            url_entry += f"<changefreq>{escape_xml(changefreq)}</changefreq>"
+        url_entry += "</url>"
+        self.write_to_sitemap(url_entry)
 
     def add_urls(self, urls: Iterator[str]):
         """

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -91,7 +91,9 @@ class XMLSitemap:
         self.sitemap_urls_counter += 1
 
         if self.sitemap_urls_counter > self.URLS_PER_FILE:
-            self.logger.info(f"URLs per sitemap counter reached the limit of {self.URLS_PER_FILE}")
+            self.logger.info(
+                f"URLs per sitemap counter reached the limit of {self.URLS_PER_FILE}"
+            )
             self._add_sitemap()
             self.sitemap_urls_counter = 1
 

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -96,7 +96,8 @@ class XMLSitemap:
         changefreq: Optional[str] = None,
     ):
         """
-        Adds the provided URL to the sitemap (with optional lastmod, priority and changefreq properties)
+        Adds the provided URL to the sitemap,
+        with optional lastmod, priority and changefreq properties
         https://www.sitemaps.org/protocol.html#xmlTagDefinitions
         """
         if self.sitemap_urls_counter == 0:

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -77,7 +77,7 @@ class XMLSitemap:
         self.add_section("pages")
 
 
-def add_url(
+    def add_url(
         self,
         url: str,
         lastmod: Optional[str] = None,

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -28,12 +28,23 @@ CHANGEFREQ_VALUES = {
 }
 
 def is_valid_date(date_str: str) -> bool:
+    """
+    Checks if the provided string matches the W3C timestamp format
+    """
     return W3C_DATE_REGEX.match(date_str) or W3C_DATETIME_REGEX.match(date_str)
 
 def is_valid_changefreq(changefreq: str) -> bool:
+    """
+    Checks if the provided string is one of the valid values for the <changefreq> tag
+    https://www.sitemaps.org/protocol.html#changefreqdef
+    """
     return changefreq in CHANGEFREQ_VALUES
 
 def is_valid_priority(priority: str) -> bool:
+    """
+    Checks if the provided string is a valid numeric value for the <priority> tag
+    https://www.sitemaps.org/protocol.html#prioritydef
+    """
     try:
         value = float(priority)
         return 0.0 <= value <= 1.0

--- a/xml_sitemap_writer.py
+++ b/xml_sitemap_writer.py
@@ -77,7 +77,13 @@ class XMLSitemap:
         self.add_section("pages")
 
 
-    def add_url(self, url: str, lastmod: Optional[str] = None, priority: Optional[str] = None, changefreq: Optional[str] = None):
+def add_url(
+        self,
+        url: str,
+        lastmod: Optional[str] = None,
+        priority: Optional[str] = None,
+        changefreq: Optional[str] = None,
+    ):
         if self.sitemap_urls_counter == 0:
             self._add_sitemap()
 


### PR DESCRIPTION

- **Implemented validation for <lastmod>**: Ensured the date follows the W3C date format (YYYY-MM-DD) or the full W3C datetime format (YYYY-MM-DDThh:mm:ss±hh:mm or YYYY-MM-DDThh:mm:ssZ). Added a regex check to validate the date format.

- **Implemented validation for <changefreq>**: Restricted the values to the allowed set: {"always", "hourly", "daily", "weekly", "monthly", "yearly", "never"}. Added a function to check the validity of the `changefreq` value.

- **Implemented validation for <priority>**: Ensured the priority is a float value between 0.0 and 1.0. Added a function to validate the `priority` value.

- **Updated `add_url` method**:
  - Added checks for the validity of the `lastmod`, `changefreq`, and `priority` parameters.
  - If the values are invalid, they are not included in the sitemap entry, and a warning is logged.

- **Added regex patterns and validation functions**:
  - `W3C_DATE_REGEX`: Matches the date format YYYY-MM-DD.
  - `W3C_DATETIME_REGEX`: Matches the full datetime format YYYY-MM-DDThh:mm:ss±hh:mm or YYYY-MM-DDThh:mm:ssZ.
  - `is_valid_date`: Validates whether a given date string matches the W3C date or datetime format.
  - `is_valid_changefreq`: Checks if `changefreq` is one of the allowed values.
  - `is_valid_priority`: Checks if `priority` is a float between 0.0 and 1.0.

- **Logging**:
  - Added logging warnings for invalid `lastmod`, `changefreq`, and `priority` values when they are encountered in the `add_url` method.

These changes ensure that only correctly formatted values are included in the sitemap, enhancing the robustness and compliance of the generated XML sitemaps with the standard protocols.